### PR TITLE
Get rid of deprecated np.asmatrix()

### DIFF
--- a/python/ad_disp_data.py
+++ b/python/ad_disp_data.py
@@ -7,16 +7,17 @@ m = 30    #number of contracts
 T = 60    #number of periods
 
 #number of impressions in each period
-I = 10*np.random.rand(T, 1); I = np.asmatrix(I)
+I = 10*np.random.rand(T, 1)
 #revenue rate for each period and ad
-R = np.random.rand(n, T); R = np.asmatrix(R)
+R = np.random.rand(n, T)
 #contract target number of impressions
-q = T/float(n)*50*np.random.rand(m, 1); q = np.asmatrix(q)
+q = T/float(n)*50*np.random.rand(m, 1)
 #penalty rate for shortfall
-p = np.random.rand(m, 1); p = np.asmatrix(p)
+p = np.random.rand(m, 1)
 #one column per contract. 1's at the periods to be displayed
 Tcontr = np.matrix(np.random.rand(T, m)>.8, dtype = float)
-Acontr = np.zeros((n, m)); Acont = np.asmatrix(Acontr)
+Acontr = np.zeros((n, m))
+Acont = Acontr
 for i in range(n):
     contract=int(np.floor(m*np.random.rand(1)))
     #one column per contract. 1's at the ads to be displayed

--- a/python/ad_disp_data.py
+++ b/python/ad_disp_data.py
@@ -7,13 +7,13 @@ m = 30    #number of contracts
 T = 60    #number of periods
 
 #number of impressions in each period
-I = 10*np.random.rand(T, 1)
+I = 10*np.random.rand(T)
 #revenue rate for each period and ad
 R = np.random.rand(n, T)
 #contract target number of impressions
-q = T/float(n)*50*np.random.rand(m, 1)
+q = T/float(n)*50*np.random.rand(m)
 #penalty rate for shortfall
-p = np.random.rand(m, 1)
+p = np.random.rand(m)
 #one column per contract. 1's at the periods to be displayed
 Tcontr = np.matrix(np.random.rand(T, m)>.8, dtype = float)
 Acontr = np.zeros((n, m))

--- a/python/hybrid_veh_data.py
+++ b/python/hybrid_veh_data.py
@@ -9,10 +9,8 @@ import matplotlib.pyplot as plt
 # define Preq, required power at wheels
 # Preq is piecewise linear
 # a is slope of each piece
-#a=np.asmatrix('[0.5 -0.5 0.2 -0.7 0.6 -0.2 0.7 -0.5 0.8 -0.4]')
 a=[0.5, -0.5, 0.2, -0.7, 0.6, -0.2, 0.7, -0.5, 0.8, -0.4]
 # l is length of each piece
-#l=np.asmatrix('[40 20 40 40 20 40 30 40 30 60]', dtype='float')
 l=[40, 20, 40, 40, 20, 40, 30, 40, 30, 60]
 
 Preq=np.arange(a[0],a[0]*(l[0]+0.5),a[0])

--- a/python/ml_estim_incr_signal_data.py
+++ b/python/ml_estim_incr_signal_data.py
@@ -11,12 +11,11 @@ xtrue[69:80] = 0.15
 xtrue[79] = 1
 xtrue = np.cumsum(xtrue)
 
-# pass the increasing input through a moving-average filter 
+# pass the increasing input through a moving-average filter
 # and add Gaussian noise
 h = np.array([1, -0.85, 0.7, -0.3])
 k = h.size
 yhat = np.convolve(h,xtrue)
 y = yhat[0:-3].reshape(N,1) + np.random.randn(N,1)
 
-xtrue = np.asmatrix(xtrue.reshape(N,1))
-y = np.asmatrix(y)
+xtrue = xtrue.reshape(N,1)

--- a/python/ml_estim_incr_signal_data.py
+++ b/python/ml_estim_incr_signal_data.py
@@ -15,7 +15,5 @@ xtrue = np.cumsum(xtrue)
 # and add Gaussian noise
 h = np.array([1, -0.85, 0.7, -0.3])
 k = h.size
-yhat = np.convolve(h,xtrue)
-y = yhat[0:-3].reshape(N,1) + np.random.randn(N,1)
-
-xtrue = xtrue.reshape(N,1)
+yhat = np.convolve(h, xtrue)
+y = yhat[0:-3] + np.random.randn(N)

--- a/python/simple_portfolio_data.py
+++ b/python/simple_portfolio_data.py
@@ -2,10 +2,11 @@ import numpy as np
 
 np.random.seed(1)
 n = 20
-pbar = np.ones((n,1))*.03 + np.r_[np.random.rand(n-1,1), np.zeros((1,1))]*.12;
-S = np.random.randn(n, n); S = np.asmatrix(S)
+pbar = np.ones((n,1))*.03 + np.r_[np.random.rand(n-1,1), np.zeros((1,1))]*.12
+S = np.random.randn(n, n)
 S = S.T*S
 S = S/max(np.abs(np.diag(S)))*.2
-S[:, -1] = np.zeros((n, 1))
-S[-1, :] = np.zeros((n, 1)).T
-x_unif = np.ones((n, 1))/n; x_unit = np.asmatrix(x_unif)
+S[:, -1] = np.zeros(n)
+S[-1, :] = np.zeros(n).T
+x_unif = np.ones((n, 1))/n
+x_unit = x_unif

--- a/python/simple_portfolio_data.py
+++ b/python/simple_portfolio_data.py
@@ -2,11 +2,11 @@ import numpy as np
 
 np.random.seed(1)
 n = 20
-pbar = np.ones((n,1))*.03 + np.r_[np.random.rand(n-1,1), np.zeros((1,1))]*.12
+pbar = np.ones(n)*.03 + np.r_[np.random.rand(n-1), np.zeros(1)]*.12
 S = np.random.randn(n, n)
-S = S.T*S
+S = S.T @ S
 S = S/max(np.abs(np.diag(S)))*.2
 S[:, -1] = np.zeros(n)
 S[-1, :] = np.zeros(n).T
-x_unif = np.ones((n, 1))/n
+x_unif = np.ones(n)/n
 x_unit = x_unif

--- a/python/sparse_lds_data.py
+++ b/python/sparse_lds_data.py
@@ -7,20 +7,19 @@ np.random.seed(123)
 n = 8
 A = sprandn(n, n, 0.2).todense()
 A = 0.95*A/np.max(np.abs(np.linalg.eigvals(A))) # make A stable.
-A = np.asmatrix(A)
 
 m = 4
-B = np.asmatrix(sprandn(n, m, 0.3).todense())
+B = sprandn(n, m, 0.3).todense()
 
 T = 100
-W = np.asmatrix(np.eye(n))
-Whalf = np.asmatrix(sqrtm(W))
+W = np.eye(n)
+Whalf = sqrtm(W)
 
-us = np.asmatrix(10*np.random.randn(m, T-1)) #input.
-ws = np.dot(Whalf, np.asmatrix(np.random.randn(n, T))) #noise process.
+us = 10*np.random.randn(m, T-1) #input.
+ws = np.dot(Whalf, np.random.randn(n, T)) #noise process.
 
-xs = np.asmatrix(np.zeros((n, T)))
-xs[:, 0] = 50*np.random.randn(n, 1) #initial x.
+xs = np.zeros((n, T))
+xs[:, 0] = 50*np.random.randn(n) #initial x.
 
 # Simulate the system.
 for t in range(T-1):


### PR DESCRIPTION
Per lecture in EE364A on 7/25/23. np.asmatrix() has been long deprecated and should be removed from code